### PR TITLE
Improve license update workflow to create a PR for changes

### DIFF
--- a/.github/workflows/main-ci.yaml
+++ b/.github/workflows/main-ci.yaml
@@ -48,17 +48,19 @@ jobs:
       - name: Generate third-party licenses
         run: |
           poetry run pip-licenses --format=markdown --output-file=third_party_licenses.md
-      - name: Commit and push changes
+      - name: Commit, push changes to new branch, and create PR
         run: |
+          BRANCH_NAME="update-licenses-$(date +%s)"
           git config --local user.name "github-actions"
           git config --local user.email "github-actions@github.com"
           if [ -n "$(git status --porcelain third_party_licenses.md)" ]; then
+            git checkout -b $BRANCH_NAME
             git add third_party_licenses.md
             git commit -m "Update third-party licenses"
-            git push
+            git push origin $BRANCH_NAME
+            gh pr create --title "Update third-party licenses" --body "This PR updates the third_party_licenses.md file." --head $BRANCH_NAME --base main
           else
-            echo "No changes in third_party_licenses.md. Skipping commit and push."
+            echo "No changes in third_party_licenses.md. Skipping commit, push, and PR creation."
           fi
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-


### PR DESCRIPTION
This pull request updates the CI workflow to improve the handling of changes to the `third_party_licenses.md` file. The most significant change is the addition of logic to create a new branch and pull request when updates are detected.

### Changes to CI workflow:
* [`.github/workflows/main-ci.yaml`](diffhunk://#diff-b0d5efbc98f2beec0f86a1de733c7d2f3a459fea85cbfc2d2baa9ba3e9da2f03L51-L64): Updated the "Commit and push changes" step to create a new branch (`update-licenses-<timestamp>`), push changes to that branch, and automatically open a pull request titled "Update third-party licenses" if the `third_party_licenses.md` file has been modified.