### PR TITLE
Update GitHub Actions to use PERSONAL_ACCESS_TOKEN for GITHUB_TOKEN

### DIFF
--- a/.github/workflows/main-ci.yaml
+++ b/.github/workflows/main-ci.yaml
@@ -63,4 +63,4 @@ jobs:
             echo "No changes in third_party_licenses.md. Skipping commit, push, and PR creation."
           fi
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.PERSONAL_ACCESS_TOKEN }}


### PR DESCRIPTION
This pull request updates the authentication method in the `.github/workflows/main-ci.yaml` file to use a personal access token instead of the default GitHub token for CI workflows.

* [`.github/workflows/main-ci.yaml`](diffhunk://#diff-b0d5efbc98f2beec0f86a1de733c7d2f3a459fea85cbfc2d2baa9ba3e9da2f03L66-R66): Changed the `GITHUB_TOKEN` environment variable to use `${{ secrets.PERSONAL_ACCESS_TOKEN }}` for enhanced security or additional permissions.