### PR TITLE
feat: update version to 0.12.0-rc in pyproject.toml; implement failback strategy in file processing with enhanced error handling and test coverage

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "hcl-processor"
-version = "0.11.2-b"
+version = "0.12.0-rc"
 description = "A tool for analyzing HCL files."
 authors = ["S-mishina <45090872+S-mishina@users.noreply.github.com>"]
 packages = [{ include = "hcl_processor", from = "src" }]


### PR DESCRIPTION
This pull request introduces a significant refactor of the HCL file processing workflow in the `hcl-processor` project, along with enhancements to the failback strategy and expanded test coverage. The changes improve modularity, error handling, and testability. Key updates include splitting the workflow into smaller functions, refining the failback strategy for chunk processing, and adding comprehensive tests for various failback scenarios.

### Refactoring and modularization:

* Reorganized the `run_hcl_file_workflow` function by extracting key steps into smaller, reusable internal functions such as `_execute_failback_strategy`, `_process_main_bedrock_api`, `_write_output_files`, and `_load_and_prepare_hcl_data`. These changes improve code readability and maintainability (`src/hcl_processor/file_processor.py`, [[1]](diffhunk://#diff-bb8e59d8364603561b76a14c3a7d481745cfcada02f61aa322f3339dbb5d40ffL15-L77) [[2]](diffhunk://#diff-bb8e59d8364603561b76a14c3a7d481745cfcada02f61aa322f3339dbb5d40ffR51-R181).

### Failback strategy improvements:

* Enhanced the failback strategy to process resources in chunks, allowing partial success even when individual chunks fail. Added logging for successful and skipped chunks, and ensured the workflow continues despite errors (`src/hcl_processor/file_processor.py`, [[1]](diffhunk://#diff-bb8e59d8364603561b76a14c3a7d481745cfcada02f61aa322f3339dbb5d40ffL15-L77) [[2]](diffhunk://#diff-bb8e59d8364603561b76a14c3a7d481745cfcada02f61aa322f3339dbb5d40ffR51-R181).

### Test coverage expansion:

* Added new tests to validate the failback strategy, including scenarios for resource type handling, chunk error pass strategy, flattened list extension errors, and failback disabled in both debug and non-debug modes (`tests/test_file_processor.py`, [tests/test_file_processor.pyR182-R407](diffhunk://#diff-199fce2a4721da99372fc7f4ac8e285239e08e5527acce67a201c5d5a9a939f1R182-R407)).

### Version update:

* Updated the project version from `0.11.2-b` to `0.12.0-rc` in `pyproject.toml` to reflect the new changes and improvements (`pyproject.toml`, [pyproject.tomlL3-R3](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711L3-R3)).